### PR TITLE
Fix Readme: specify the port

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ cd digitalmusicstand
 ## Usage
 
 ```bash
-./digitalmusicstand --sheets /path/to/pdfs --port 3000
+./digitalmusicstand --sheets /path/to/pdfs --listen :3000
 ```
 
 The files in the sheet directoy need to follow the convention `interpret_title.pdf`.


### PR DESCRIPTION
It seems that the command line has changed.

Now it's `--listen :3000` instead of `--port 3000`.